### PR TITLE
feat: allow custom hook events

### DIFF
--- a/metahub.js
+++ b/metahub.js
@@ -197,7 +197,7 @@ Metahub.prototype.createComment = function (number, body) {
 
 Metahub.prototype.createHook = function () {
 
-  var msg = _.defaults({
+  var msg = _.defaults(this.config.msg, {
     name: 'web',
     active: true,
     events: [
@@ -209,7 +209,7 @@ Metahub.prototype.createHook = function () {
       url: this.config.hook.url,
       content_type: 'json'
     }
-  }, this.config.msg);
+  });
 
   return this.rest.repos.createHook(msg);
 };


### PR DESCRIPTION
`createHook` can now extend a custom `config.msg`, not the other way around.

Custom mary-poppins configurations are able to `install` custom events plugins may need. For example, I needed the `pull_request_review_comment` event in [poppins-pr-vote](https://github.com/frapontillo/poppins-pr-vote).
